### PR TITLE
C++: add tl_across_translation_units test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# Build directories
+build*/
+
+# VScode
+.vscode/

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -1,0 +1,65 @@
+set (CMAKE_CXX_STANDARD 23)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if ((CMAKE_SYSTEM_NAME MATCHES "Linux"))
+  set (OS_LINUX 1)
+  add_definitions(-D OS_LINUX)
+else()
+  message (FATAL_ERROR "Platform ${CMAKE_SYSTEM_NAME} is not supported")
+endif ()
+
+# By default, disable compiler optimizations 
+# and keep debug info, to enable easier assembly
+# inspection, being a testing repository.
+# CMAKE_BUILD_TYPE of Debug implies -O0 -g for the compiler.
+#
+# Other build types are not supported.
+if (NOT CMAKE_BUILD_TYPE)
+  set (CMAKE_BUILD_TYPE "Debug")
+endif ()
+
+set (CMAKE_BUILD_TYPE 
+  "${CMAKE_BUILD_TYPE}" 
+  CACHE 
+  STRING 
+  "Choose the type of build." 
+  FORCE)
+
+include (FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE # requires CMake 3.24
+)
+FetchContent_MakeAvailable (googletest)
+
+function (_build_test name)
+  cmake_parse_arguments (parsed_args
+  ""
+  ""
+  "SOURCES;LIBRARIES"
+  ${ARGN})
+  
+  if (NOT parsed_args_SOURCES)
+    message (FATAL_ERROR "No source files provided for test ${name}.")
+  endif ()
+
+  set (target ${name}_test)
+
+  add_executable (${target} ${parsed_args_SOURCES})
+  
+  target_compile_options (${target} PRIVATE -Wall -Wextra)
+  
+  if (parsed_args_LIBRARIES)
+    target_link_libraries (${target} ${parsed_args_LIBRARIES})
+  endif()
+endfunction ()
+
+_build_test (tl_across_translation_units
+  SOURCES 
+    tl_across_translation_units/tl_across_translation_units_test.cc
+    tl_across_translation_units/tl_defs_impl.cc
+    tl_across_translation_units/tl_defs.hh
+  LIBRARIES
+    gtest_main
+)

--- a/C++/tl_across_translation_units/tl_across_translation_units_test.cc
+++ b/C++/tl_across_translation_units/tl_across_translation_units_test.cc
@@ -1,0 +1,104 @@
+#include <thread>
+#include <latch>
+#include <vector>
+
+#if defined(OS_LINUX)
+#include <fstream>
+#include <cstring>
+#include <format>
+#include <string>
+#endif
+
+#include "gtest/gtest.h"
+#include "tl_defs.hh"
+
+static unsigned long self_static_memory_usage_kib();
+
+#if defined(OS_LINUX)
+struct statm {
+    unsigned long size;
+    unsigned long resident;
+    unsigned long share;
+    unsigned long text;
+    unsigned long lib;
+    unsigned long data;
+    unsigned long dt;
+};
+
+static statm self_statm();
+#endif
+
+TEST(tl_across_translation_units, statically_linked_executable) {
+    const int THREAD_COUNT = 4;
+    std::vector<std::thread> threads;
+    std::latch threads_created_latch(THREAD_COUNT);
+    std::latch unblock_threads_latch(1);
+    
+    // get_thread_area() syscall is highly architecture specific,
+    // and the standard library doesn't provide a portable wrapper.
+    // In addition, we dont want to depend on a specific userspace allocator (like mallinfo()).
+    // Furthermore, per thread memory usage is more complex to retrieve,
+    // and the total/sum provides similar information. 
+    // So, we just check the total system allocated memory for the
+    // program.
+    // We record the memory usage before the threads creation and 
+    // later subtract to improve the accuracy of the test.
+    auto static_memory_usage_kib_before = self_static_memory_usage_kib();
+
+    for (int i = 0; i < THREAD_COUNT; ++i) {
+        threads.emplace_back([&threads_created_latch, &unblock_threads_latch] () {
+            threads_created_latch.count_down();
+            unblock_threads_latch.wait();
+        });
+    }
+    
+    threads_created_latch.wait();
+    
+    long static_memory_usage_kib_after = self_static_memory_usage_kib();
+    ASSERT_GE(static_memory_usage_kib_after - static_memory_usage_kib_before, THREAD_COUNT * TL_SIZE_BYTES / 1024) 
+        << "Memory usage including thread local area is less than expected";
+
+    unblock_threads_latch.count_down();
+    for (auto& t : threads) {
+        t.join();
+    }
+}
+
+static unsigned long self_static_memory_usage_kib() {
+#if defined(OS_LINUX)
+    return self_statm().size;
+#else
+    throw std::runtime_error("self_static_memory_usage_kib() is not implemented for this platform");
+#endif
+}
+
+#if defined(OS_LINUX)
+static statm self_statm() {
+    auto statm_path = "/proc/self/statm";
+    std::ifstream statm_file(statm_path);
+    if (!statm_file) {
+        throw std::runtime_error(std::format("Failed to open {}", statm_path));
+    }
+
+    statm buf;
+    statm_file >> buf.size >> buf.resident >> buf.share >> buf.text >> buf.lib >> buf.data >> buf.dt;
+    
+    // A dummy ' ' for checking bad I/O before isspace() on the second iteration and onwards,
+    // and calling fail() only when eof() returns false.
+    auto trailing_whitespace = std::string(1, ' ');
+    // The first iteration checks the previous data I/O.
+    do {
+        if (statm_file.bad()) {
+            throw std::runtime_error(std::format("I/O error while reading from file {}", statm_path));
+        }
+        if (statm_file.fail()) {
+            throw std::runtime_error(std::format("Non-integer data encountered from file {}", statm_path));
+        }
+        if (!std::isspace(trailing_whitespace[0])) {
+            throw std::runtime_error("Unsupported proc_pid_statm file format");
+        }
+        statm_file.read(&trailing_whitespace[0], 1);
+    } while (!statm_file.eof());
+    return buf;
+}
+#endif

--- a/C++/tl_across_translation_units/tl_defs.hh
+++ b/C++/tl_across_translation_units/tl_defs.hh
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+// A relatively big thread local area size, to dominate memory usage and
+// improve check accuracy.
+const long TL_SIZE_BYTES = 2 * 1024 * 1024;
+
+const long PAGE_SIZE = 4096; // Assuming a 4KiB regular page size
+static_assert(TL_SIZE_BYTES >= 2 * 1024 * 1024, "Thread local area size is too small for the check to be reliable");
+static_assert(TL_SIZE_BYTES % PAGE_SIZE == 0, "Unaligned thread local area size");
+
+void dummy_cross_translation_units_unused();

--- a/C++/tl_across_translation_units/tl_defs_impl.cc
+++ b/C++/tl_across_translation_units/tl_defs_impl.cc
@@ -1,0 +1,6 @@
+#include "tl_defs.hh"
+#include <cstddef>
+
+thread_local uint8_t big_tl[TL_SIZE_BYTES] = {1};
+
+void dummy_cross_translation_units_unused() {}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required (VERSION 3.24)
+
+project (thread-local-test)
+
+add_subdirectory (C++)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # thread-local-test
+
+A test suite to validate various aspects of implicit thread local storage implementation on target platforms.
+
+Implicit thread local storage means that the program does not directly manage it, but rather uses a platform provided implementation. Usually, the interface is part of the programming langauge, like thread_local storage classifier in C++11 and C23.
+
+The implementation is rather complex, and involves cooperation of compiler, static linker, dynamic linker, kernel, ISA, and langauge runtime. Here is a [deep dive reference](https://chao-tic.github.io/blog/2018/12/25/tls).
+
+## Build
+
+To build the test suite, run the following command:
+
+```bash
+./build.py
+```
+
+It will generate test executables under the `build` directory.

--- a/build.py
+++ b/build.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+
+ROOT_PATH = os.path.realpath(os.path.dirname(__file__))
+
+DEFAULT_BUILD_DIR = "build"
+DEFAULT_BUILD_PATH = os.path.join(ROOT_PATH, DEFAULT_BUILD_DIR)
+
+CMAKE_CMD = "cmake"
+
+def configure():
+    os.makedirs(DEFAULT_BUILD_DIR, exist_ok=True)
+    subprocess.run(
+        [CMAKE_CMD, "-S", ROOT_PATH, "-B", DEFAULT_BUILD_PATH],
+        check=True
+    )
+
+def build():
+    subprocess.run(
+        [CMAKE_CMD, "--build", DEFAULT_BUILD_PATH],
+        check=True
+    )
+
+def main():
+    configure()
+    build()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a test for C++11 thread_local, that validates that thread local variables are allocated at runtime across translation units for created threads, where the thread local is statically linked against the threads driver executable, but not declared or defined there.