### PR TITLE
C: add new test tl_across_translation_unit

### DIFF
--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -1,7 +1,7 @@
 include (tl_add_test)
 
-set (CMAKE_CXX_STANDARD 23)
-set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_C_STANDARD 23)
+set (CMAKE_C_STANDARD_REQUIRED ON)
 
 if ((CMAKE_SYSTEM_NAME MATCHES "Linux"))
   set (OS_LINUX 1)
@@ -27,23 +27,14 @@ set (CMAKE_BUILD_TYPE
   "Choose the type of build." 
   FORCE)
 
-include (FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
-  DOWNLOAD_EXTRACT_TIMESTAMP TRUE # requires CMake 3.24
-)
-FetchContent_MakeAvailable (googletest)
-
 set (DEFAULT_COMPILER_FLAGS -Wall -Wextra)
 
-tl_add_test (cxx_tl_across_translation_units
+tl_add_test (c_tl_across_translation_units
   SOURCES 
-    tl_across_translation_units/tl_across_translation_units_test.cc
-    tl_across_translation_units/tl_defs_impl.cc
-    tl_across_translation_units/tl_defs.hh
+    tl_across_translation_units/tl_across_translation_units_test.c
+    tl_across_translation_units/tl_defs_impl.c
+    tl_across_translation_units/tl_defs.h
   COMPILER_FLAGS
     ${DEFAULT_COMPILER_FLAGS}
-  LIBRARIES
-    gtest_main
+    -pthread
 )

--- a/C/tl_across_translation_units/tl_across_translation_units_test.c
+++ b/C/tl_across_translation_units/tl_across_translation_units_test.c
@@ -1,0 +1,159 @@
+#include <stdio.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+#include "tl_defs.h"
+
+#define handle_errno(err, msg) do { errno = err; perror(msg); exit(EXIT_FAILURE); } while (0);
+
+typedef struct latch {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int count;
+} latch;
+
+// If count is negative or greater than INT_MAX, the behaviour is undefined.
+void latch_init(latch *l, int count);
+
+void latch_destroy(latch *l);
+
+// If the count down size is negative or greater than the internal counter, the behaviour is undefined.
+void latch_count_down(latch *l);
+void latch_count_down_n(latch *l, int n);
+
+void latch_wait(latch *l);
+
+static void *thread_signal_and_wait(void *_unused);
+
+// Returns the size of data + stack virtual memory for the ciurrent process in KiBs.
+static long vm_self_data_and_stack_size(void);
+
+#if defined(OS_LINUX)
+typedef struct statm {
+    unsigned long size;
+    unsigned long resident;
+    unsigned long share;
+    unsigned long text;
+    unsigned long lib;
+    unsigned long data;
+    unsigned long dt;
+} statm;
+
+static void vm_self_statm(statm*);
+#endif
+
+static latch threads_created_latch;
+static latch unblock_threads_latch;
+
+int main() {
+    const int THREAD_COUNT = 4;
+    pthread_t threads[THREAD_COUNT];
+    latch_init(&threads_created_latch, THREAD_COUNT);
+    latch_init(&unblock_threads_latch, 1);
+
+    // get_thread_area() syscall is highly architecture specific,
+    // and the standard library doesn't provide a portable wrapper.
+    // In addition, we dont want to depend on a specific userspace allocator (like mallinfo()).
+    // Furthermore, per thread memory usage is more complex to retrieve,
+    // and the total/sum provides similar information. 
+    // So, we just check the total system allocated memory for the
+    // program.
+    // We record the memory usage before the threads creation and 
+    // later subtract to improve the accuracy of the test.
+    long static_memory_usage_kib_before = vm_self_data_and_stack_size();
+
+    for (int i = 0; i < THREAD_COUNT; ++i) {
+        pthread_create(&threads[i], NULL, thread_signal_and_wait, NULL);
+    }
+
+    latch_wait(&threads_created_latch);
+
+    long static_memory_usage_kib_after = vm_self_data_and_stack_size();
+    if (static_memory_usage_kib_after - static_memory_usage_kib_before < THREAD_COUNT * TL_SIZE_BYTES / 1024) {
+        fprintf(stderr, "Memory usage including thread local area is less than expected\n");
+        exit(EXIT_FAILURE);
+    }
+
+    latch_count_down(&unblock_threads_latch);
+    for (int i = 0; i < THREAD_COUNT; ++i) {
+        pthread_join(threads[i], NULL);
+    }
+    latch_destroy(&threads_created_latch);
+    latch_destroy(&unblock_threads_latch);
+    printf("Test passed\n");
+    return 0;
+}
+
+static void *thread_signal_and_wait(void *unused) {
+    (void)unused; // suppress unused parameter warning
+    latch_count_down(&threads_created_latch);
+    latch_wait(&unblock_threads_latch);
+    return NULL; // unused
+}
+
+void latch_init(latch *l, int count) {
+    pthread_mutex_init(&l->mutex, NULL);
+    pthread_cond_init(&l->cond, NULL);
+    l->count = count;
+}
+
+void latch_destroy(latch *l) {
+    pthread_mutex_destroy(&l->mutex);
+    pthread_cond_destroy(&l->cond);
+}
+
+void latch_count_down(latch *l) {
+    latch_count_down_n(l, 1);
+}
+
+void latch_count_down_n(latch *l, int n) {
+    pthread_mutex_lock(&l->mutex);
+    l->count -= n;
+    if (!l->count) {
+        pthread_cond_broadcast(&l->cond);
+    }
+    pthread_mutex_unlock(&l->mutex);
+}
+
+void latch_wait(latch *l) {
+    pthread_mutex_lock(&l->mutex);
+    while (l->count > 0) {
+        pthread_cond_wait(&l->cond, &l->mutex);
+    }
+    pthread_mutex_unlock(&l->mutex);
+}
+
+
+static long vm_self_data_and_stack_size(void) {
+#if defined(OS_LINUX)
+    statm s;
+    vm_self_statm(&s);
+    return s.data;
+#else
+    handle_errno(ENOTSUP, "Reading memory statistics is not supported on this platform");
+#endif
+}
+
+#if defined(OS_LINUX)
+static void vm_self_statm(statm *s) {
+    int errno_restore = errno;
+    const char *statm_path = "/proc/self/statm";
+    FILE *statm_file = fopen(statm_path, "r");
+    if (!statm_file) {
+        errno_restore = errno;
+        goto cleanup;
+    }
+    if(fscanf(statm_file, "%lu %lu %lu %lu %lu %lu %lu", 
+            &s->size, &s->resident, &s->share, &s->text, &s->lib, &s->data, &s->dt) != 7) {
+        errno_restore = errno;
+        goto cleanup;
+    }
+    return;
+cleanup:
+    if (statm_file) {
+        fclose(statm_file);
+    }
+    handle_errno(errno_restore, "Error reading /proc/self/statm");
+}
+#endif

--- a/C/tl_across_translation_units/tl_defs.h
+++ b/C/tl_across_translation_units/tl_defs.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// A relatively big thread local area size, to dominate memory usage and
+// improve check accuracy.
+#define TL_SIZE_BYTES (2 * 1024 * 1024)
+
+#define PAGE_SIZE (4096) // Assuming a 4KiB regular page size
+static_assert(TL_SIZE_BYTES >= 2 * 1024 * 1024, "Thread local area size is too small for the check to be reliable");
+static_assert(TL_SIZE_BYTES % PAGE_SIZE == 0, "Unaligned thread local area size");
+
+void dummy_cross_translation_units_unused();

--- a/C/tl_across_translation_units/tl_defs_impl.c
+++ b/C/tl_across_translation_units/tl_defs_impl.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+
+#include "tl_defs.h"
+
+thread_local uint8_t big_tl[TL_SIZE_BYTES] = {1};
+
+void dummy_cross_translation_units_unused() {}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,3 +5,4 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 project (thread-local-test)
 
 add_subdirectory (C++)
+add_subdirectory (C)


### PR DESCRIPTION
This patchset adds a new C subdirectory and first cross TU thread_local test. The new test uses only C for proper isolation, and the logic is similar to the C++ test.

The test executables are renamed with a language prefix to resolve ambiguity.